### PR TITLE
Sanitize headers and json values within requests and responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,21 @@ Optionally you can disable the network requests capturing with:
 VITE_OPENREPLAY_CAPTURE_NETWORK=false
 ```
 
+When network capture has been enabled you should redact some values like passwords.
+We have a default list which you can extend by adding:
+```
+VITE_OPENREPLAY_SANITIZE_HEADERS="Token Authorization"
+VITE_OPENREPLAY_SANITIZE_JSON_VALUES="new_password password email"
+```
+
+For more advanced sanitization you can set 
+```js
+// https://docs.openreplay.com/en/installation/network-options/
+window.openreplaySanitizer = (requestAndResponse) => {
+    return requestAndResponse;
+}
+```
+
 ## License
 
 GNU General Public License v3. Please see [License File](LICENSE) for more information.

--- a/resources/js/openreplay.js
+++ b/resources/js/openreplay.js
@@ -3,11 +3,73 @@ import Tracker from '@openreplay/tracker'
 const captureNetwork = import.meta.env.VITE_OPENREPLAY_CAPTURE_NETWORK === undefined
     || import.meta.env.VITE_OPENREPLAY_CAPTURE_NETWORK === 'true'
 
+// https://docs.openreplay.com/en/installation/network-options/
+const openreplaySanitizer = (requestAndResponse) => {
+    for (const headerToSanitize of ['Authorization', 'X-CSRF-Token']) {
+        if (requestAndResponse.request.headers[headerToSanitize]) {
+            requestAndResponse.request.headers[headerToSanitize] = '***'
+        }
+    }
+
+    if (typeof requestAndResponse.request.body !== 'string') {
+        // If the request body is not a string, we do not save it.
+        // As this will be one of https://developer.mozilla.org/en-US/docs/Web/API/RequestInit#body
+        requestAndResponse.request.body = ''
+    }
+
+    let responseBodyString = requestAndResponse.response.body
+    if (typeof responseBodyString === 'object') {
+        try {
+            responseBodyString = JSON.stringify(responseBodyString)
+        } catch (e) {
+            // Rather safe than sorry, if it fails we empty the response body
+            responseBodyString = '{}'
+        }
+    }
+
+    for (const jsonValuesToSanitize of [
+        'password', 
+        'token',
+        'mask',
+        'cart_id',
+        'postcode',
+        'city',
+        'customer_telephone',
+        'telephone',
+        'fax',
+        'vat_id',
+        'po_number',
+        'pay_return_url',
+        'pay_redirect_url',
+        'iban'
+    ]) {
+        const re = new RegExp(`("?${jsonValuesToSanitize}"?: ?")([^"]+)(")`, 'g')
+        requestAndResponse.request.body = requestAndResponse.request.body?.replaceAll(re, '$1***$3')
+        responseBodyString = responseBodyString.replaceAll(re, '$1***$3')
+    }
+
+    if (typeof requestAndResponse.response.body === 'object') {
+        try {
+            requestAndResponse.response.body = JSON.parse(responseBodyString)
+        } catch (e) {
+            // Ignore error
+        }
+    }
+
+    // After we've done sanitisation, we could allow the user to sanitize further.
+    if (window.openreplaySanitizer) {
+        requestAndResponse = window.openreplaySanitizer(requestAndResponse);
+    }
+
+    return requestAndResponse
+}
+
 const tracker = new Tracker({
     projectKey: import.meta.env.VITE_OPENREPLAY_TOKEN,
     ingestPoint: import.meta.env.VITE_OPENREPLAY_URL,
     network: {
-        capturePayload: captureNetwork
+        capturePayload: captureNetwork,
+        sanitizer: openreplaySanitizer,
     }
 })
 

--- a/resources/js/openreplay.js
+++ b/resources/js/openreplay.js
@@ -5,7 +5,14 @@ const captureNetwork = import.meta.env.VITE_OPENREPLAY_CAPTURE_NETWORK === undef
 
 // https://docs.openreplay.com/en/installation/network-options/
 const openreplaySanitizer = (requestAndResponse) => {
-    for (const headerToSanitize of ['Authorization', 'X-CSRF-Token']) {
+    for (const headerToSanitize of [
+        'Authorization', 
+        'X-CSRF-Token',
+        ...(import.meta.env.VITE_OPENREPLAY_SANITIZE_HEADERS || '').split(/ |,/),
+    ]) {
+        if (!headerToSanitize) {
+            continue;
+        }
         if (requestAndResponse.request.headers[headerToSanitize]) {
             requestAndResponse.request.headers[headerToSanitize] = '***'
         }
@@ -27,7 +34,7 @@ const openreplaySanitizer = (requestAndResponse) => {
         }
     }
 
-    for (const jsonValuesToSanitize of [
+    for (const jsonValueToSanitize of [
         'password', 
         'token',
         'mask',
@@ -41,9 +48,13 @@ const openreplaySanitizer = (requestAndResponse) => {
         'po_number',
         'pay_return_url',
         'pay_redirect_url',
-        'iban'
+        'iban',
+        ...(import.meta.env.VITE_OPENREPLAY_SANITIZE_JSON_VALUES || '').split(/ |,/),
     ]) {
-        const re = new RegExp(`("?${jsonValuesToSanitize}"?: ?")([^"]+)(")`, 'g')
+        if (!jsonValueToSanitize) {
+            continue;
+        }
+        const re = new RegExp(`("?${jsonValueToSanitize}"?: ?")([^"]+)(")`, 'g')
         requestAndResponse.request.body = requestAndResponse.request.body?.replaceAll(re, '$1***$3')
         responseBodyString = responseBodyString.replaceAll(re, '$1***$3')
     }


### PR DESCRIPTION
Since we're tracking network requests we must sanitize the data so no sensitive data could accidentally get stored:
https://docs.openreplay.com/en/installation/network-options/

This PR aims to sanitize headers and json values (both in request and response) after which a custom sanitizer could be executed.
For security reasons we would not want it to be possible to easily overwrite the sanitizer BEFORE it has done it's sanitization

Here's an example of what the result would look like:
```json
{
    "url": "https://magento.test/graphql",
    "method": "POST",
    "status": 200,
    "request": {
        "headers": {
            "Store": "default",
            "Content-Type": "application/json"
        },
        "body": "{\"query\":\"mutation generateCustomerToken ($email: String!, $password: String!) { generateCustomerToken (email: $email, password: $password) { token } }\",\"variables\":{\"email\":\"test@example.com\",\"password\":\"***\"}}"
    },
    "response": {
        "headers": {
            "cache-control": "max-age=0, must-revalidate, no-cache, no-store",
            "content-type": "application/json",
            "expires": "Wed, 01 May 2024 09:37:12 GMT",
            "pragma": "no-cache"
        },
        "body": {
            "errors": [
                {
                    "message": "De account-aanmelding is onjuist of uw account is tijdelijk uitgeschakeld. Wacht even en probeer het later opnieuw.",
                    "locations": [
                        {
                            "line": 1,
                            "column": 72
                        }
                    ],
                    "path": [
                        "generateCustomerToken"
                    ],
                    "extensions": {
                        "category": "graphql-authentication"
                    }
                }
            ],
            "data": {
                "generateCustomerToken": null
            }
        }
    }
}
```

See the `"password\":\"***\"` in the request body