### PR TITLE
Implement reporting to the graphql panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Integration for https://openreplay.com
 ## Installation
 
 ```
-yarn add @openreplay/tracker -D
+yarn add @openreplay/tracker @openreplay/tracker-graphql -D
 ```
 
 ```


### PR DESCRIPTION
This implements reporting to the graphql panel in openreplay described by https://docs.openreplay.com/en/tutorials/graphql/

Since we can't directly hook into the fetch methods we can get all data we need after sanitization.
I have left the option to ignore the network request in the future in case of Graphql but from my understanding in the code we want to send both the network request and the graphql query.

The isGraphql check is based on OpenRepays check https://github.com/openreplay/openreplay/blob/66b485cccffa3b9d93e4f432effac8a2ff3d171b/networkProxy/src/networkMessage.ts#L59

**BREAKING**
users **must** now install the `@openreplay/tracker-graphql` package as well.