### PR TITLE
Prevent errors if response is empty

### DIFF
--- a/resources/js/openreplay.js
+++ b/resources/js/openreplay.js
@@ -56,7 +56,7 @@ const openreplaySanitizer = (requestAndResponse) => {
         }
         const re = new RegExp(`("?${jsonValueToSanitize}"?: ?")([^"]+)(")`, 'g')
         requestAndResponse.request.body = requestAndResponse.request.body?.replaceAll(re, '$1***$3')
-        responseBodyString = responseBodyString.replaceAll(re, '$1***$3')
+        responseBodyString = responseBodyString?.replaceAll(re, '$1***$3')
     }
 
     if (typeof requestAndResponse.response.body === 'object') {
@@ -65,6 +65,8 @@ const openreplaySanitizer = (requestAndResponse) => {
         } catch (e) {
             // Ignore error
         }
+    } else {
+        requestAndResponse.response.body = responseBodyString
     }
 
     // After we've done sanitisation, we could allow the user to sanitize further.


### PR DESCRIPTION
If the responseBody is empty or undefined we could get errors.
Also ensure we overwrite the body even if the body is not an object